### PR TITLE
calling save without attr to preserve types of embedded objects

### DIFF
--- a/lib/minimongoid.coffee
+++ b/lib/minimongoid.coffee
@@ -263,7 +263,7 @@ class @Minimongoid
     attr.createdAt ||= new Date()
     attr = @before_create(attr) if @before_create
     doc = @init(attr)
-    doc = doc.save(attr)
+    doc = doc.save()
     if doc and @after_create
       @after_create(doc)
     else


### PR DESCRIPTION
Hi there,

thanks for minimongoid, I'm just getting started with Meteor, this is a great help.
I just noticed that if you create an object with embedded documents, in the object returned by create() the embedded documents have lost their type as save() doesnt parse the attributes passed to it. And this second passing of the attributes within the create method doesn't seem necessary. Or am I missing something?

Cheers,

Niels
