### PR TITLE
Quick fix on defaults also including non-instance properties

### DIFF
--- a/lib/minimongoid.coffee
+++ b/lib/minimongoid.coffee
@@ -46,7 +46,7 @@ class @Minimongoid
         @[name] = value
 
     # load in defaults
-    for attr, val of @constructor.defaults
+    for own attr, val of @constructor.defaults
       @[attr] = val if typeof @[attr] is 'undefined'
 
 


### PR DESCRIPTION
The defaults override will also set as new property any new
Array.prototype override because of the “of” keyword in coffeescript.

E.g. if you define Array.prototype.sample = function() {}, sample will
then be present in the default overrides.

The way to fix is to use own, to make sure only the instance properties
of defaults is applied.
